### PR TITLE
Fix iOS app name and location permission message

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Runner</string>
+	<string>Hikage Finder</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -25,9 +25,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>$(PRODUCT_NAME) は、ルート検索・移動時に、あなたの現在位置を利用します。</string>
+	<string>"Hikage Finder"は、ルート検索・移動時に、あなたの現在位置を利用します。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>$(PRODUCT_NAME) は、ルート検索・移動時に、あなたの現在位置を利用します。</string>
+	<string>"Hikage Finder"は、ルート検索・移動時に、あなたの現在位置を利用します。</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
@dkastl  
I missed to set wrong app display name and location permission message, so I fixed those.